### PR TITLE
feat: CRUD de usuários e disciplinas com segurança JWT

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./mvnw compile:*)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,10 @@
 {
   "permissions": {
     "allow": [
-      "Bash(./mvnw compile:*)"
+      "Bash(./mvnw compile:*)",
+      "Bash(./mvnw spring-boot:run)",
+      "Bash(curl -s http://localhost:8080/health)",
+      "Bash(curl:*)"
     ]
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>

--- a/src/main/java/com/aps/eduflow/controller/DisciplinaController.java
+++ b/src/main/java/com/aps/eduflow/controller/DisciplinaController.java
@@ -1,0 +1,83 @@
+package com.aps.eduflow.controller;
+
+import com.aps.eduflow.domain.dto.DisciplinaRequestDTO;
+import com.aps.eduflow.domain.dto.DisciplinaResponseDTO;
+import com.aps.eduflow.service.DisciplinaService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/disciplinas")
+public class DisciplinaController {
+
+    private final DisciplinaService disciplinaService;
+
+    public DisciplinaController(DisciplinaService disciplinaService) {
+        this.disciplinaService = disciplinaService;
+    }
+
+    /**
+     * Criar nova disciplina — requer ADMIN ou PROFESSOR.
+     */
+    @PostMapping
+    @Secured({"ROLE_ADMIN", "ROLE_PROFESSOR"})
+    public ResponseEntity<DisciplinaResponseDTO> criar(@RequestBody @Valid DisciplinaRequestDTO dto) {
+        DisciplinaResponseDTO response = disciplinaService.criar(dto);
+
+        URI location = ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path("/disciplinas/{id}")
+                .buildAndExpand(response.getId())
+                .toUri();
+
+        return ResponseEntity.created(location).body(response);
+    }
+
+    /**
+     * Listar todas as disciplinas — aberto para autenticados, ordenado alfabeticamente.
+     * Suporta filtro por busca (?busca=Algoritmos ou ?busca=ADS).
+     */
+    @GetMapping
+    public ResponseEntity<List<DisciplinaResponseDTO>> listar(
+            @RequestParam(required = false) String busca) {
+        List<DisciplinaResponseDTO> response = disciplinaService.listar(busca);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Detalhes de uma disciplina específica — aberto para autenticados.
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<DisciplinaResponseDTO> buscarPorId(@PathVariable Long id) {
+        DisciplinaResponseDTO response = disciplinaService.buscarPorId(id);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Atualizar disciplina — requer ADMIN ou PROFESSOR.
+     */
+    @PutMapping("/{id}")
+    @Secured({"ROLE_ADMIN", "ROLE_PROFESSOR"})
+    public ResponseEntity<DisciplinaResponseDTO> atualizar(
+            @PathVariable Long id,
+            @RequestBody @Valid DisciplinaRequestDTO dto) {
+        DisciplinaResponseDTO response = disciplinaService.atualizar(id, dto);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Excluir disciplina (soft delete) — requer ADMIN.
+     * Valida se não há monitores ou atendimentos vinculados.
+     */
+    @DeleteMapping("/{id}")
+    @Secured({"ROLE_ADMIN"})
+    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+        disciplinaService.deletar(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/aps/eduflow/controller/UsuarioController.java
+++ b/src/main/java/com/aps/eduflow/controller/UsuarioController.java
@@ -1,59 +1,128 @@
 package com.aps.eduflow.controller;
 
 import com.aps.eduflow.domain.dto.CadastroUsuarioRequest;
+import com.aps.eduflow.domain.dto.UsuarioResponseDTO;
+import com.aps.eduflow.domain.dto.UsuarioUpdateRequestDTO;
 import com.aps.eduflow.domain.entity.Usuario;
+import com.aps.eduflow.domain.enums.UserRole;
+import com.aps.eduflow.domain.exception.RegraNegocioException;
 import com.aps.eduflow.domain.repository.UsuarioRepository;
+import com.aps.eduflow.infra.security.UserDetailsServiceImpl;
+import com.aps.eduflow.service.UsuarioService;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import java.net.URI;
 import java.util.List;
 
 @RestController
+@RequestMapping("/usuarios")
 public class UsuarioController {
 
-    private final UsuarioRepository usuarioRepository;
-    private final PasswordEncoder passwordEncoder;
+    private final UsuarioService usuarioService;
+    private final UserDetailsServiceImpl userDetailsService;
 
-    public UsuarioController(UsuarioRepository usuarioRepository, PasswordEncoder passwordEncoder) {
-        this.usuarioRepository = usuarioRepository;
-        this.passwordEncoder = passwordEncoder;
+    public UsuarioController(UsuarioService usuarioService, UserDetailsServiceImpl userDetailsService) {
+        this.usuarioService = usuarioService;
+        this.userDetailsService = userDetailsService;
     }
 
-    @PostMapping("/usuarios/cadastrar")
-    public ResponseEntity<?> cadastrar(@RequestBody @Valid CadastroUsuarioRequest dto) {
-        if (usuarioRepository.existsByEmail(dto.getEmail())) {
-            return ResponseEntity.badRequest().body("Já existe um usuário com esse e-mail");
-        }
+    /**
+     * Auto-cadastro público — role será sempre ALUNO.
+     */
+    @PostMapping("/cadastrar")
+    public ResponseEntity<UsuarioResponseDTO> cadastrar(@RequestBody @Valid CadastroUsuarioRequest dto) {
+        UsuarioResponseDTO response = usuarioService.cadastrar(dto);
 
-        if (usuarioRepository.existsByMatricula(dto.getMatricula())) {
-            return ResponseEntity.badRequest().body("Já existe um usuário com essa matrícula");
-        }
+        URI location = ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path("/usuarios/{id}")
+                .buildAndExpand(response.getId())
+                .toUri();
 
-        Usuario usuario = new Usuario(
-                null,
-                dto.getNome(),
-                dto.getEmail(),
-                passwordEncoder.encode(dto.getSenha()),
-                dto.getMatricula(),
-                dto.getRole(),
-                null
-        );
-
-        usuario = usuarioRepository.save(usuario);
-        return ResponseEntity.ok(new UsuarioResponse(usuario));
+        return ResponseEntity.created(location).body(response);
     }
 
-    @GetMapping("/usuarios")
-    public ResponseEntity<List<Usuario>> listarTodos() {
-        return ResponseEntity.ok(usuarioRepository.findAll());
+    /**
+     * Cadastro com role definido — requer ADMIN ou PROFESSOR.
+     */
+    @PostMapping
+    @Secured({"ROLE_ADMIN", "ROLE_PROFESSOR"})
+    public ResponseEntity<UsuarioResponseDTO> cadastrarComRole(@RequestBody @Valid CadastroUsuarioRequest dto) {
+        UserRole roleAutorizado = getRoleAutenticado();
+        UsuarioResponseDTO response = usuarioService.cadastrarComRole(dto, roleAutorizado);
+
+        URI location = ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path("/usuarios/{id}")
+                .buildAndExpand(response.getId())
+                .toUri();
+
+        return ResponseEntity.created(location).body(response);
     }
 
-    private record UsuarioResponse(Long id, String nome, String email, String matricula, String role) {
-        UsuarioResponse(Usuario u) {
-            this(u.getId(), u.getNome(), u.getEmail(), u.getMatricula(), u.getRole().name());
-        }
+    /**
+     * Buscar usuário por ID.
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<UsuarioResponseDTO> buscarPorId(@PathVariable Long id) {
+        UsuarioResponseDTO response = usuarioService.buscarPorId(id);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Listar todos os usuários, com filtro opcional por role.
+     */
+    @GetMapping
+    @Secured({"ROLE_ADMIN"})
+    public ResponseEntity<List<UsuarioResponseDTO>> listar(
+            @RequestParam(required = false) UserRole role) {
+        List<UsuarioResponseDTO> response = usuarioService.listarTodos(role);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Atualizar dados cadastrais — requer ADMIN ou PROFESSOR.
+     */
+    @PutMapping("/{id}")
+    @Secured({"ROLE_ADMIN", "ROLE_PROFESSOR"})
+    public ResponseEntity<UsuarioResponseDTO> atualizar(
+            @PathVariable Long id,
+            @RequestBody @Valid UsuarioUpdateRequestDTO dto) {
+        UserRole roleAutorizado = getRoleAutenticado();
+        UsuarioResponseDTO response = usuarioService.atualizar(id, dto, roleAutorizado);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Promover role de um usuário — ADMIN e PROFESSOR podem promover a MONITOR;
+     * somente ADMIN pode criar PROFESSOR.
+     */
+    @DeleteMapping("/{id}")
+    @Secured({"ROLE_ADMIN"})
+    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+        usuarioService.deletar(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Promover role de um usuário — ADMIN e PROFESSOR podem promover a MONITOR;
+     * somente ADMIN pode criar PROFESSOR.
+     */
+    @PatchMapping("/{id}/role")
+    @Secured({"ROLE_ADMIN", "ROLE_PROFESSOR"})
+    public ResponseEntity<UsuarioResponseDTO> promoverRole(
+            @PathVariable Long id,
+            @RequestParam UserRole novaRole) {
+        UserRole roleAutorizado = getRoleAutenticado();
+        UsuarioResponseDTO response = usuarioService.promoverRole(id, novaRole, roleAutorizado);
+        return ResponseEntity.ok(response);
+    }
+
+    private UserRole getRoleAutenticado() {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        return userDetailsService.findByEmail(email).getRole();
     }
 }

--- a/src/main/java/com/aps/eduflow/domain/dto/CadastroUsuarioRequest.java
+++ b/src/main/java/com/aps/eduflow/domain/dto/CadastroUsuarioRequest.java
@@ -3,7 +3,6 @@ package com.aps.eduflow.domain.dto;
 import com.aps.eduflow.domain.enums.UserRole;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -30,6 +29,5 @@ public class CadastroUsuarioRequest {
     @NotBlank(message = "A matrícula é obrigatória")
     private String matricula;
 
-    @NotNull(message = "O perfil de acesso é obrigatório")
     private UserRole role;
 }

--- a/src/main/java/com/aps/eduflow/domain/dto/DisciplinaRequestDTO.java
+++ b/src/main/java/com/aps/eduflow/domain/dto/DisciplinaRequestDTO.java
@@ -1,0 +1,24 @@
+package com.aps.eduflow.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class DisciplinaRequestDTO {
+
+    @NotBlank(message = "O nome é obrigatório")
+    private String nome;
+
+    @NotBlank(message = "O código é obrigatório")
+    @Pattern(regexp = "^[A-Za-z]{3}[0-9]{3}$", message = "O código deve ter o formato 3 letras e 3 números (ex: ADS101)")
+    private String codigo;
+
+    private String descricao;
+}

--- a/src/main/java/com/aps/eduflow/domain/dto/DisciplinaResponseDTO.java
+++ b/src/main/java/com/aps/eduflow/domain/dto/DisciplinaResponseDTO.java
@@ -1,0 +1,20 @@
+package com.aps.eduflow.domain.dto;
+
+import com.aps.eduflow.domain.entity.Disciplina;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DisciplinaResponseDTO {
+
+    private Long id;
+    private String nome;
+    private String codigo;
+    private String descricao;
+    private Boolean ativo;
+
+    public DisciplinaResponseDTO(Disciplina d) {
+        this(d.getId(), d.getNome(), d.getCodigo(), d.getDescricao(), d.getAtivo());
+    }
+}

--- a/src/main/java/com/aps/eduflow/domain/dto/UsuarioResponseDTO.java
+++ b/src/main/java/com/aps/eduflow/domain/dto/UsuarioResponseDTO.java
@@ -1,0 +1,20 @@
+package com.aps.eduflow.domain.dto;
+
+import com.aps.eduflow.domain.entity.Usuario;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UsuarioResponseDTO {
+
+    private Long id;
+    private String nome;
+    private String email;
+    private String matricula;
+    private String role;
+
+    public UsuarioResponseDTO(Usuario u) {
+        this(u.getId(), u.getNome(), u.getEmail(), u.getMatricula(), u.getRole().name());
+    }
+}

--- a/src/main/java/com/aps/eduflow/domain/dto/UsuarioUpdateRequestDTO.java
+++ b/src/main/java/com/aps/eduflow/domain/dto/UsuarioUpdateRequestDTO.java
@@ -1,0 +1,25 @@
+package com.aps.eduflow.domain.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class UsuarioUpdateRequestDTO {
+
+    @NotBlank(message = "O nome é obrigatório")
+    private String nome;
+
+    @NotBlank(message = "O e-mail é obrigatório")
+    @Email(message = "E-mail inválido")
+    private String email;
+
+    @NotBlank(message = "A matrícula é obrigatória")
+    private String matricula;
+}

--- a/src/main/java/com/aps/eduflow/domain/entity/Disciplina.java
+++ b/src/main/java/com/aps/eduflow/domain/entity/Disciplina.java
@@ -26,6 +26,17 @@ public class Disciplina {
     @Column(nullable = false, unique = true, length = 20)
     private String codigo;
 
+    private String descricao;
+
+    @Column(nullable = false)
+    private Boolean ativo;
+
+    @OneToMany(mappedBy = "disciplina", fetch = FetchType.LAZY)
+    private List<Monitoria> monitorias;
+
+    @OneToMany(mappedBy = "disciplina", fetch = FetchType.LAZY)
+    private List<Atendimento> atendimentos;
+
     @CreationTimestamp
     @Column(name = "data_criacao", nullable = false, updatable = false)
     private LocalDateTime dataCriacao;

--- a/src/main/java/com/aps/eduflow/domain/exception/ConflitoException.java
+++ b/src/main/java/com/aps/eduflow/domain/exception/ConflitoException.java
@@ -1,0 +1,8 @@
+package com.aps.eduflow.domain.exception;
+
+public class ConflitoException extends RuntimeException {
+
+    public ConflitoException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/aps/eduflow/domain/exception/RegraNegocioException.java
+++ b/src/main/java/com/aps/eduflow/domain/exception/RegraNegocioException.java
@@ -1,0 +1,8 @@
+package com.aps.eduflow.domain.exception;
+
+public class RegraNegocioException extends RuntimeException {
+
+    public RegraNegocioException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/aps/eduflow/domain/repository/AtendimentoRepository.java
+++ b/src/main/java/com/aps/eduflow/domain/repository/AtendimentoRepository.java
@@ -20,4 +20,6 @@ public interface AtendimentoRepository extends JpaRepository<Atendimento, Long> 
     List<Atendimento> findByMonitorIdAndStatus(Long monitorId, SessionStatus status);
 
     List<Atendimento> findByMonitorIdAndDataHoraBetween(Long monitorId, LocalDateTime inicio, LocalDateTime fim);
+
+    boolean existsByDisciplinaId(Long disciplinaId);
 }

--- a/src/main/java/com/aps/eduflow/domain/repository/DisciplinaRepository.java
+++ b/src/main/java/com/aps/eduflow/domain/repository/DisciplinaRepository.java
@@ -3,6 +3,7 @@ package com.aps.eduflow.domain.repository;
 import com.aps.eduflow.domain.entity.Disciplina;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface DisciplinaRepository extends JpaRepository<Disciplina, Long> {
@@ -10,4 +11,12 @@ public interface DisciplinaRepository extends JpaRepository<Disciplina, Long> {
     Optional<Disciplina> findByCodigo(String codigo);
 
     boolean existsByCodigo(String codigo);
+
+    boolean existsByCodigoAndIdNot(String codigo, Long id);
+
+    List<Disciplina> findByAtivoTrueOrderByNomeAsc();
+
+    List<Disciplina> findByNomeContainingIgnoreCaseOrderByNomeAsc(String nome);
+
+    List<Disciplina> findByCodigoContainingIgnoreCaseOrderByNomeAsc(String codigo);
 }

--- a/src/main/java/com/aps/eduflow/domain/repository/MonitoriaRepository.java
+++ b/src/main/java/com/aps/eduflow/domain/repository/MonitoriaRepository.java
@@ -12,4 +12,6 @@ public interface MonitoriaRepository extends JpaRepository<Monitoria, Long> {
     List<Monitoria> findByDisciplinaId(Long disciplinaId);
 
     boolean existsByMonitorIdAndDisciplinaId(Long monitorId, Long disciplinaId);
+
+    boolean existsByDisciplinaId(Long disciplinaId);
 }

--- a/src/main/java/com/aps/eduflow/infra/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/aps/eduflow/infra/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.aps.eduflow.infra.excecao;
 
+import com.aps.eduflow.domain.exception.ConflitoException;
 import com.aps.eduflow.domain.exception.RegraNegocioException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,11 @@ import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ConflitoException.class)
+    public ResponseEntity<ErrorResponse> handleConflito(ConflitoException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(new ErrorResponse(ex.getMessage()));
+    }
 
     @ExceptionHandler(RegraNegocioException.class)
     public ResponseEntity<ErrorResponse> handleRegraNegocio(RegraNegocioException ex) {

--- a/src/main/java/com/aps/eduflow/infra/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/aps/eduflow/infra/exception/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.aps.eduflow.infra.excecao;
+
+import com.aps.eduflow.domain.exception.RegraNegocioException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RegraNegocioException.class)
+    public ResponseEntity<ErrorResponse> handleRegraNegocio(RegraNegocioException ex) {
+        return ResponseEntity.badRequest().body(new ErrorResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex) {
+        String mensagem = ex.getBindingResult().getFieldErrors().stream()
+                .map(e -> e.getDefaultMessage())
+                .collect(Collectors.joining("; "));
+        return ResponseEntity.badRequest().body(new ErrorResponse(mensagem));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponse("Acesso negado"));
+    }
+
+    private record ErrorResponse(String mensagem) {
+    }
+}

--- a/src/main/java/com/aps/eduflow/infra/security/SecurityConfig.java
+++ b/src/main/java/com/aps/eduflow/infra/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -17,6 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
 public class SecurityConfig {
 
     @Autowired

--- a/src/main/java/com/aps/eduflow/service/DisciplinaService.java
+++ b/src/main/java/com/aps/eduflow/service/DisciplinaService.java
@@ -1,0 +1,107 @@
+package com.aps.eduflow.service;
+
+import com.aps.eduflow.domain.dto.DisciplinaRequestDTO;
+import com.aps.eduflow.domain.dto.DisciplinaResponseDTO;
+import com.aps.eduflow.domain.entity.Disciplina;
+import com.aps.eduflow.domain.exception.ConflitoException;
+import com.aps.eduflow.domain.exception.RegraNegocioException;
+import com.aps.eduflow.domain.repository.AtendimentoRepository;
+import com.aps.eduflow.domain.repository.DisciplinaRepository;
+import com.aps.eduflow.domain.repository.MonitoriaRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class DisciplinaService {
+
+    private final DisciplinaRepository disciplinaRepository;
+    private final MonitoriaRepository monitoriaRepository;
+    private final AtendimentoRepository atendimentoRepository;
+
+    public DisciplinaService(DisciplinaRepository disciplinaRepository,
+                             MonitoriaRepository monitoriaRepository,
+                             AtendimentoRepository atendimentoRepository) {
+        this.disciplinaRepository = disciplinaRepository;
+        this.monitoriaRepository = monitoriaRepository;
+        this.atendimentoRepository = atendimentoRepository;
+    }
+
+    public DisciplinaResponseDTO criar(DisciplinaRequestDTO dto) {
+        if (disciplinaRepository.existsByCodigo(dto.getCodigo().toUpperCase())) {
+            throw new ConflitoException("Já existe uma disciplina com o código " + dto.getCodigo());
+        }
+
+        Disciplina disciplina = new Disciplina();
+        disciplina.setNome(dto.getNome());
+        disciplina.setCodigo(dto.getCodigo().toUpperCase());
+        disciplina.setDescricao(dto.getDescricao());
+        disciplina.setAtivo(true);
+
+        disciplina = disciplinaRepository.save(disciplina);
+
+        return new DisciplinaResponseDTO(disciplina);
+    }
+
+    public List<DisciplinaResponseDTO> listar(String busca) {
+        List<Disciplina> disciplinas;
+
+        if (busca != null && !busca.isBlank()) {
+            if (busca.matches("^[A-Za-z]{3}.*")) {
+                disciplinas = disciplinaRepository.findByCodigoContainingIgnoreCaseOrderByNomeAsc(busca);
+            } else {
+                disciplinas = disciplinaRepository.findByNomeContainingIgnoreCaseOrderByNomeAsc(busca);
+            }
+        } else {
+            disciplinas = disciplinaRepository.findByAtivoTrueOrderByNomeAsc();
+        }
+
+        return disciplinas.stream()
+                .map(DisciplinaResponseDTO::new)
+                .toList();
+    }
+
+    public DisciplinaResponseDTO buscarPorId(Long id) {
+        Disciplina disciplina = disciplinaRepository.findById(id)
+                .orElseThrow(() -> new RegraNegocioException("Disciplina não encontrada"));
+        return new DisciplinaResponseDTO(disciplina);
+    }
+
+    public DisciplinaResponseDTO atualizar(Long id, DisciplinaRequestDTO dto) {
+        Disciplina disciplina = disciplinaRepository.findById(id)
+                .orElseThrow(() -> new RegraNegocioException("Disciplina não encontrada"));
+
+        if (!disciplina.getCodigo().equals(dto.getCodigo().toUpperCase())
+                && disciplinaRepository.existsByCodigoAndIdNot(dto.getCodigo().toUpperCase(), id)) {
+            throw new ConflitoException("Já existe uma disciplina com o código " + dto.getCodigo());
+        }
+
+        disciplina.setNome(dto.getNome());
+        disciplina.setCodigo(dto.getCodigo().toUpperCase());
+        disciplina.setDescricao(dto.getDescricao());
+
+        disciplina = disciplinaRepository.save(disciplina);
+
+        return new DisciplinaResponseDTO(disciplina);
+    }
+
+    public void deletar(Long id) {
+        Disciplina disciplina = disciplinaRepository.findById(id)
+                .orElseThrow(() -> new RegraNegocioException("Disciplina não encontrada"));
+
+        if (!disciplina.getAtivo()) {
+            throw new RegraNegocioException("Disciplina já está inativa");
+        }
+
+        if (monitoriaRepository.existsByDisciplinaId(id)) {
+            throw new RegraNegocioException("Não é possível excluir: existem monitores vinculados a esta disciplina");
+        }
+
+        if (atendimentoRepository.existsByDisciplinaId(id)) {
+            throw new RegraNegocioException("Não é possível excluir: existem atendimentos registrados nesta disciplina");
+        }
+
+        disciplina.setAtivo(false);
+        disciplinaRepository.save(disciplina);
+    }
+}

--- a/src/main/java/com/aps/eduflow/service/UsuarioService.java
+++ b/src/main/java/com/aps/eduflow/service/UsuarioService.java
@@ -1,0 +1,145 @@
+package com.aps.eduflow.service;
+
+import com.aps.eduflow.domain.dto.CadastroUsuarioRequest;
+import com.aps.eduflow.domain.dto.UsuarioResponseDTO;
+import com.aps.eduflow.domain.dto.UsuarioUpdateRequestDTO;
+import com.aps.eduflow.domain.entity.Usuario;
+import com.aps.eduflow.domain.enums.UserRole;
+import com.aps.eduflow.domain.exception.RegraNegocioException;
+import com.aps.eduflow.domain.repository.UsuarioRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class UsuarioService {
+
+    private final UsuarioRepository usuarioRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UsuarioService(UsuarioRepository usuarioRepository, PasswordEncoder passwordEncoder) {
+        this.usuarioRepository = usuarioRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public UsuarioResponseDTO cadastrar(CadastroUsuarioRequest dto) {
+        if (usuarioRepository.existsByEmail(dto.getEmail())) {
+            throw new RegraNegocioException("Já existe um usuário com esse e-mail");
+        }
+
+        if (usuarioRepository.existsByMatricula(dto.getMatricula())) {
+            throw new RegraNegocioException("Já existe um usuário com essa matrícula");
+        }
+
+        Usuario usuario = new Usuario();
+        usuario.setNome(dto.getNome());
+        usuario.setEmail(dto.getEmail());
+        usuario.setMatricula(dto.getMatricula());
+        usuario.setSenha(passwordEncoder.encode(dto.getSenha()));
+
+        // Auto-cadastro: role é sempre ALUNO
+        usuario.setRole(UserRole.ALUNO);
+
+        usuario = usuarioRepository.save(usuario);
+
+        return new UsuarioResponseDTO(usuario);
+    }
+
+    public UsuarioResponseDTO cadastrarComRole(CadastroUsuarioRequest dto, UserRole roleAutorizado) {
+        // ADMIN pode criar qualquer role; PROFESSOR pode criar MONITOR
+        validarPermissaoCriacao(dto.getRole(), roleAutorizado);
+
+        if (usuarioRepository.existsByEmail(dto.getEmail())) {
+            throw new RegraNegocioException("Já existe um usuário com esse e-mail");
+        }
+
+        if (usuarioRepository.existsByMatricula(dto.getMatricula())) {
+            throw new RegraNegocioException("Já existe um usuário com essa matrícula");
+        }
+
+        Usuario usuario = new Usuario();
+        usuario.setNome(dto.getNome());
+        usuario.setEmail(dto.getEmail());
+        usuario.setMatricula(dto.getMatricula());
+        usuario.setSenha(passwordEncoder.encode(dto.getSenha()));
+        usuario.setRole(dto.getRole());
+
+        usuario = usuarioRepository.save(usuario);
+
+        return new UsuarioResponseDTO(usuario);
+    }
+
+    public UsuarioResponseDTO buscarPorId(Long id) {
+        Usuario usuario = usuarioRepository.findById(id)
+                .orElseThrow(() -> new RegraNegocioException("Usuário não encontrado"));
+        return new UsuarioResponseDTO(usuario);
+    }
+
+    public List<UsuarioResponseDTO> listarTodos(UserRole role) {
+        List<Usuario> usuarios;
+        if (role != null) {
+            usuarios = usuarioRepository.findByRole(role);
+        } else {
+            usuarios = usuarioRepository.findAll();
+        }
+        return usuarios.stream()
+                .map(UsuarioResponseDTO::new)
+                .toList();
+    }
+
+    public UsuarioResponseDTO atualizar(Long id, UsuarioUpdateRequestDTO dto, UserRole roleAutorizado) {
+        Usuario usuario = usuarioRepository.findById(id)
+                .orElseThrow(() -> new RegraNegocioException("Usuário não encontrado"));
+
+        // Verifica se o e-mail está sendo trocado e se já existe outro com esse e-mail
+        if (!usuario.getEmail().equals(dto.getEmail()) && usuarioRepository.existsByEmail(dto.getEmail())) {
+            throw new RegraNegocioException("Já existe um usuário com esse e-mail");
+        }
+
+        // Verifica se a matrícula está sendo trocada e se já existe outra com esse valor
+        if (!usuario.getMatricula().equals(dto.getMatricula()) && usuarioRepository.existsByMatricula(dto.getMatricula())) {
+            throw new RegraNegocioException("Já existe um usuário com essa matrícula");
+        }
+
+        usuario.setNome(dto.getNome());
+        usuario.setEmail(dto.getEmail());
+        usuario.setMatricula(dto.getMatricula());
+
+        usuario = usuarioRepository.save(usuario);
+
+        return new UsuarioResponseDTO(usuario);
+    }
+
+    public UsuarioResponseDTO promoverRole(Long id, UserRole novaRole, UserRole roleAutorizado) {
+        // ADMIN e PROFESSOR podem promover a MONITOR; só ADMIN pode criar PROFESSOR
+        validarPermissaoCriacao(novaRole, roleAutorizado);
+
+        Usuario usuario = usuarioRepository.findById(id)
+                .orElseThrow(() -> new RegraNegocioException("Usuário não encontrado"));
+
+        usuario.setRole(novaRole);
+        usuario = usuarioRepository.save(usuario);
+
+        return new UsuarioResponseDTO(usuario);
+    }
+
+    public void deletar(Long id) {
+        if (!usuarioRepository.existsById(id)) {
+            throw new RegraNegocioException("Usuário não encontrado");
+        }
+        usuarioRepository.deleteById(id);
+    }
+
+    private void validarPermissaoCriacao(UserRole roleDesejada, UserRole roleAutorizado) {
+        if (roleAutorizado == UserRole.ADMIN) {
+            return; // ADMIN pode qualquer coisa
+        }
+
+        if (roleAutorizado == UserRole.PROFESSOR && roleDesejada == UserRole.MONITOR) {
+            return; // PROFESSOR pode promover a MONITOR
+        }
+
+        throw new RegraNegocioException("Você não tem permissão para atribuir o perfil " + roleDesejada.name());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+# PostgreSQL - Neon
 spring.datasource.url=jdbc:postgresql://${DB_URL}
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASS}
@@ -6,7 +7,6 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
 server.port=8080
 


### PR DESCRIPTION
 ## Summary
  - Implementação completa do CRUD de usuários com gestão de perfis (ALUNO, MONITOR, PROFESSOR, ADMIN)
  - Implementação completa do CRUD de disciplinas com soft delete e validação de integridade
  - Autenticação JWT stateless com Spring Security
  - Senhas criptografadas com BCrypt
  - Autorização granular por role (ADMIN, PROFESSOR, MONITOR, ALUNO)
  - Tratamento global de exceções com @ControllerAdvice
  - Validações com Bean Validation (@NotBlank, @Email, @Pattern)

  ## Endpoints implementados
  - `POST /usuarios/cadastrar` - Auto-cadastro (role ALUNO)
  - `GET /usuarios/{id}` - Detalhes do perfil
  - `PUT /usuarios/{id}` - Atualização (ADMIN/PROFESSOR)
  - `DELETE /usuarios/{id}` - Exclusão (ADMIN)
  - `PATCH /usuarios/{id}/role` - Promoção de role (ADMIN/PROFESSOR)
  - `POST /disciplinas` - Criação (ADMIN/PROFESSOR)
  - `GET /disciplinas` - Listagem com filtro por busca
  - `PUT /disciplinas/{id}` - Atualização (ADMIN/PROFESSOR)
  - `DELETE /disciplinas/{id}` - Soft delete com validação de vínculos (ADMIN)
  - `POST /auth/login` - Login com geração de token JWT

  ## Test plan
  - [x] Testar auto-cadastro e verificar que role é forçado para ALUNO
  - [x] Testar login e validar retorno do token JWT
  - [x] Testar criação de disciplina com token de ADMIN
  - [x] Testar que ALUNO recebe 403 ao tentar criar disciplina
  - [x] Testar que código duplicado de disciplina retorna 409
  - [x] Testar filtro de busca em disciplinas
